### PR TITLE
Hpc logging progress

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,4 +9,6 @@ makedocs(
     sitename = "PowerSimulationNODE",
 )
 
-deploydocs(repo = "https://github.com/HodgeLab/PowerSimulationNODE.git")
+deploydocs(repo = "https://github.com/HodgeLab/PowerSimulationNODE.git",
+    branch = "gh-pages",
+    devbranch = "main")

--- a/src/HPCTrain.jl
+++ b/src/HPCTrain.jl
@@ -36,7 +36,7 @@ dataecho \$SLURM_JOB_NODELIST |sed s/\\,/\\\\n/g > hostfile
 
 {{#n_nodes}}parallel --jobs \$SLURM_CPUS_ON_NODE --slf hostfile \\ {{/n_nodes}}{{^n_nodes}}parallel --jobs \$SLURM_NPROCS \\{{/n_nodes}}
     --wd {{{project_path}}} \\
-    --progress -a {{{train_set_file}}}\\
+    -a {{{train_set_file}}}\\
     --joblog {{{project_path}}}/hpc_train.log \\
     julia --project={{{project_path}}} {{{project_path}}}/scripts/train_node.jl {}
 """


### PR DESCRIPTION
Remove --progress from the Mustache template. Prevents a bunch of ssh related logging errors when run on hpc. 