### PR TITLE
Mb/add options

### DIFF
--- a/src/PowerSimulationNODE.jl
+++ b/src/PowerSimulationNODE.jl
@@ -22,6 +22,8 @@ export build_subsystems
 export generate_train_data
 export generate_validation_data
 export generate_test_data
+export evaluate_loss
+export visualize_loss
 
 import Arrow
 import Dates

--- a/src/train/TrainParams.jl
+++ b/src/train/TrainParams.jl
@@ -207,6 +207,7 @@ mutable struct TrainParams
             NamedTuple{(:rmse, :mae), Tuple{Float64, Float64}},
         },
     }
+    force_tstops::Bool
     rng_seed::Int64
     output_mode_skip::Int64
     train_time_limit_seconds::Int64
@@ -323,6 +324,7 @@ function TrainParams(;
         ),
         type_weights = (rmse = 1.0, mae = 0.0),
     ),
+    force_tstops = true,
     rng_seed = 123,
     output_mode_skip = 1,
     train_time_limit_seconds = 1e9,
@@ -389,6 +391,7 @@ function TrainParams(;
         adjust_fix_params,
         validation_loss_every_n,
         loss_function,
+        force_tstops,
         rng_seed,
         output_mode_skip,
         train_time_limit_seconds,

--- a/src/train/instantiate.jl
+++ b/src/train/instantiate.jl
@@ -82,25 +82,43 @@ function instantiate_surrogate_psid(
     model_initializer =
         _instantiate_model_initializer(params, n_ports, scaling_extrema, flux = false)     #scaling_extrema not used in PSID NNs
     model_node = _instantiate_model_node(params, n_ports, scaling_extrema, flux = false)   #scaling_extrema not used in PSID NNs
-    model_observation =
-        _instantiate_model_observation(params, n_ports, scaling_extrema, flux = false)     #scaling_extrema not used in PSID NNs
 
-    surr = PSIDS.SteadyStateNODE(
-        name = source_name,
-        initializer_structure = model_initializer,
-        node_structure = model_node,
-        observer_structure = model_observation,
-        input_min = scaling_extrema["input_min"],
-        input_max = scaling_extrema["input_max"],
-        input_lims = params.scaling_limits.input_limits,
-        target_min = scaling_extrema["target_min"],
-        target_max = scaling_extrema["target_max"],
-        target_lims = params.scaling_limits.target_limits,
-        base_power = 100.0,
-        ext = Dict{String, Any}(),
-    )
+    if params.model_observation.type == "dense"   #If the type is "dense", instantiate SteadyStateNODEObs
+        model_observation =
+            _instantiate_model_observation(params, n_ports, scaling_extrema, flux = false)     #scaling_extrema not used in PSID NNs    
+        surr = PSIDS.SteadyStateNODEObs(
+            name = source_name,
+            initializer_structure = model_initializer,
+            node_structure = model_node,
+            observer_structure = model_observation,
+            input_min = scaling_extrema["input_min"],
+            input_max = scaling_extrema["input_max"],
+            input_lims = params.scaling_limits.input_limits,
+            target_min = scaling_extrema["target_min"],
+            target_max = scaling_extrema["target_max"],
+            target_lims = params.scaling_limits.target_limits,
+            base_power = 100.0,
+            ext = Dict{String, Any}(),
+        )
+    elseif params.model_observation.type == "DirectObservation" #If the type is "DirectObservation", instantiate SteadyStateNODE
+        surr = PSIDS.SteadyStateNODE(
+            name = source_name,
+            initializer_structure = model_initializer,
+            node_structure = model_node,
+            input_min = scaling_extrema["input_min"],
+            input_max = scaling_extrema["input_max"],
+            input_lims = params.scaling_limits.input_limits,
+            target_min = scaling_extrema["target_min"],
+            target_max = scaling_extrema["target_max"],
+            target_lims = params.scaling_limits.target_limits,
+            base_power = 100.0,
+            ext = Dict{String, Any}(),
+        )
+    else
+        @error "Invalid parameter for observation function"
+    end
     display(surr)
-    @info "SteadyStateNODE: $(surr)\n"
+    @info "Surrogate: $(surr)\n"
     return surr
 end
 
@@ -108,8 +126,6 @@ function instantiate_surrogate_flux(
     params::TrainParams,
     n_ports::Int64,
     scaling_extrema::Dict{String, Vector{Float64}},
-    #=     connecting_branches_names::Vector{Tuple{String, Symbol}},
-        sys::PSY.System, =#
 )
     steadystate_solver = instantiate_steadystate_solver(params.steady_state_solver)
     dynamic_solver = instantiate_solver(params.dynamic_solver)
@@ -128,9 +144,6 @@ function instantiate_surrogate_flux(
     @info "number of parameters: $(length(Flux.destructure(model_node)[1]))\n"
     @info "Observation structure: $(model_observation)\n"
     @info "number of parameters: $(length(Flux.destructure(model_observation)[1]))\n"
-    # connecting_branches =
-    #     [PSY.get_component(PSY.ACBranch, sys, n[1]) for n in connecting_branches_names]
-    # branch_polarity = [n[2] for n in connecting_branches_names]
     dynamic_reltol = params.dynamic_solver.reltol
     dynamic_abstol = params.dynamic_solver.abstol
     dynamic_maxiters = params.dynamic_solver.maxiters
@@ -141,8 +154,6 @@ function instantiate_surrogate_flux(
         model_initializer,
         model_node,
         model_observation,
-        # connecting_branches,
-        # branch_polarity,
         steadystate_solver,
         dynamic_solver,
         steadystate_maxiters,
@@ -464,6 +475,20 @@ function _instantiate_model_observation(params, n_ports, scaling_extrema; flux =
                 )
             end
         end
+    elseif type == "DirectObservation"
+        if flux == true
+            push!(vector_layers, (x) -> (x[1:(n_ports * SURROGATE_OUTPUT_DIM), :]))
+            push!(
+                vector_layers,
+                (x) -> (
+                    (x .- target_lims[1]) .* (target_max .- target_min) ./
+                    (target_lims[2] .- target_lims[1]) .+ target_min
+                ),
+            )
+        else
+            @error "DirectObservation incompatible with instantiating observation for PSID"
+            @assert false
+        end
     elseif type == "OutputParams"
         @error "OutputParams layer for inititalizer not yet implemented"
     end
@@ -715,7 +740,6 @@ function _cb!(
             validation_dataset,
             params.validation_data,
             connecting_branches,
-            surrogate,
             θ_ranges,
         )
 

--- a/src/train/instantiate.jl
+++ b/src/train/instantiate.jl
@@ -574,8 +574,11 @@ function _outer_loss_function(
         ii0 = train_dataset[fault_index].imag_current[1]
 
         tsteps = train_dataset[fault_index].tsteps
-        tstops = train_dataset[fault_index].tstops
-
+        if params.force_tstops == true
+            tstops = train_dataset[fault_index].tstops
+        else
+            tstops = []
+        end
         index_subset = _find_subset_batching(tsteps, train_details[timespan_index])
         real_current = train_dataset[fault_index].real_current
         real_current_subset = real_current[:, index_subset]

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
+JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ using Revise
 #using PowerFlows
 using Random
 using OrdinaryDiffEq
+using JSON3
 using PowerSimulationNODE
 using PowerSystems
 using PowerSimulationsDynamics
@@ -22,18 +23,18 @@ const PSID = PowerSimulationsDynamics
 const PSIDS = PowerSimulationsDynamicsSurrogates
 
 logger = PSY.configure_logging(;
-    console_level = PowerSimulationNODE.NODE_CONSOLE_LEVEL, # Logging.Error
+    console_level = PowerSimulationNODE.NODE_CONSOLE_LEVEL,  # Logging.Error
     file_level = PowerSimulationNODE.NODE_FILE_LEVEL,
 )
 with_logger(logger) do
-    #include("test_NLsolve.jl")     #TODO - test initialization of NODE such that NLsolve converges.       
+    include("test_NLsolve.jl")
     include("test_generate_train.jl")
     include("test_hpc.jl")
     include("test_serialize.jl")
     include("test_prettytable.jl")
     include("test_build_param_lists.jl")
     include("test_psidsurrogate_vs_trainsurrogate.jl")
-    #include("test_relative_angle.jl")   #TODO - show that the surrogate doesn't depend on absolute angle values.
+    include("test_relative_angle.jl")
 end
 flush(logger)
 close(logger)

--- a/test/test_NLsolve.jl
+++ b/test/test_NLsolve.jl
@@ -1,67 +1,158 @@
-
-#Goal: 
-#For a set of parameters, generate the training data, instantiate the surrogate, and see if the forward pass of the surrogate finds a steady state solution. 
-hidden_states = [10, 20, 40]
-for h in hidden_states
-    p = TrainParams(
-        base_path = joinpath(pwd(), "test"),
-        surrogate_buses = [2],
-        hidden_states = h,
-        model_node = (
-            type = "dense",
-            n_layer = 2,
-            width_layers = 10,
-            activation = "hardtanh",
-            σ2_initialization = 0.0,
-        ),
-        train_data = (
-            id = "1",
-            operating_points = PSIDS.SurrogateOperatingPoint[PSIDS.GenerationLoadScale()],
-            perturbations = [[
-                PSIDS.PVS(
-                    source_name = "source_1",
-                    internal_voltage_frequencies = [2 * pi],
-                    internal_voltage_coefficients = [(0.05, 0.0)],  #if you make this too large you get distortion in the sine wave from large currents? 
-                    internal_angle_frequencies = [2 * pi],
-                    internal_angle_coefficients = [(0.05, 0.0)],
-                ),
-            ]],
-            params = PSIDS.GenerateDataParams(
-                solver = "Rodas5",
-                formulation = "MassMatrix",
-                solver_tols = (reltol = 1e-6, abstol = 1e-6),
-                all_lines_dynamic = true,
+#There are some differences in the initialization in PSID and in Flux... 
+#In Flux, we test that the actual current is correct. 
+#In PSID we check that the internal current (which has a larger range) is correct. -->TODO: loosen this requirement and check condition after scaling.
+#This possibly accounts for the difference in the initial conditions that are found in this test 
+#TODO - Need a way to test if Simulation found a valid initial condition but didn't completely fail to build (see note on testing log messages below)
+@testset "Compare NLsolve convergence (flux vs psid)" begin
+    hidden_states = [5, 10, 15, 20]
+    for h in hidden_states
+        p = TrainParams(
+            base_path = joinpath(pwd(), "test"),
+            surrogate_buses = [2],
+            hidden_states = h,
+            model_node = (
+                type = "dense",
+                n_layer = 2,
+                width_layers = 10,
+                activation = "hardtanh",
+                σ2_initialization = 0.01,
             ),
-            system = "reduced",
-        ),
-        system_path = joinpath(pwd(), "test", "system_data", "test.json"),
-        rng_seed = 4,
-        dynamic_solver = (solver = "Rodas5", reltol = 1e-6, abstol = 1e-6, maxiters = 1e5),
-    )
+            train_data = (
+                id = "1",
+                operating_points = PSIDS.SurrogateOperatingPoint[PSIDS.GenerationLoadScale()],
+                perturbations = [[
+                    PSIDS.PVS(
+                        source_name = "source_1",
+                        internal_voltage_frequencies = [2 * pi],
+                        internal_voltage_coefficients = [(0.05, 0.0)],
+                        internal_angle_frequencies = [2 * pi],
+                        internal_angle_coefficients = [(0.05, 0.0)],
+                    ),
+                ]],
+                params = PSIDS.GenerateDataParams(
+                    solver = "Rodas5",
+                    formulation = "MassMatrix",
+                    solver_tols = (reltol = 1e-6, abstol = 1e-6),
+                    all_lines_dynamic = true,
+                ),
+                system = "reduced",
+            ),
+            system_path = joinpath(pwd(), "test", "system_data", "test.json"),
+            rng_seed = 4,
+            dynamic_solver = (
+                solver = "Rodas5",
+                reltol = 1e-6,
+                abstol = 1e-6,
+                maxiters = 1e5,
+            ),
+        )
 
-    @warn p.scaling_limits
-    #build_subsystems(p)
-    mkpath(joinpath(p.base_path, PowerSimulationNODE.INPUT_FOLDER_NAME))
-    #generate_train_data(p)
-    Random.seed!(p.rng_seed) #Seed call usually happens at start of train()
-    #train_dataset = Serialization.deserialize(p.train_data_path)
-    scaling_extrema = Dict{}(
-        "input_min" => [-1.0, -1.0],
-        "input_max" => [1.0, 1.0],
-        "target_min" => [-0.1, -0.1],#"target_min" => [-1.0, -1.0],
-        "target_max" => [0.0, 0.0],#"target_max" => [1.0, 1.0],
-    )
+        Random.seed!(p.rng_seed) #Seed call usually happens at start of train()
+        #These extrema come from the dataset...
+        scaling_extrema = Dict{}(
+            "input_min" => [0.8, 0.0],
+            "input_max" => [1.0, 0.2],
+            "target_min" => [0.45, -0.05],
+            "target_max" => [0.55, 0.05],
+        )
 
-    #scaling_extrema = PowerSimulationNODE.calculate_scaling_extrema(train_dataset)
-    sys_validation = System(p.surrogate_system_path)
-    sys_train = System(p.train_system_path)
-    # exs = PowerSimulationNODE._build_exogenous_input_functions(p.train_data, train_dataset)
-    ex = t -> [1.0, 0.0]
+        train_surrogate =
+            PowerSimulationNODE.instantiate_surrogate_flux(p, 1, scaling_extrema)
+        θ, _ = Flux.destructure(train_surrogate)
+        n_parameters = length(θ)
+        θ_ranges = Dict{String, UnitRange{Int64}}(
+            "initializer_range" => 1:(train_surrogate.len),
+            "node_range" =>
+                (train_surrogate.len + 1):(train_surrogate.len + train_surrogate.len2),
+            "observation_range" =>
+                (train_surrogate.len + train_surrogate.len2 + 1):n_parameters,
+        )
+        psid_surrogate = PowerSimulationNODE.instantiate_surrogate_psid(
+            p,
+            1,
+            scaling_extrema,
+            "test-source",
+        )
 
-    train_surrogate = PowerSimulationNODE.instantiate_surrogate_flux(p, 1, scaling_extrema) #Add connecting branches 
-    #WANT TO TEST IF A STEADY STATE CONDITION WAS FOUND 
-    surrogate_sol = train_surrogate(ex, [0.9, 0.1], [-0.05, -0.05], 0:0.1:1.0, 0:0.1:1.0)
-    display(scatter(surrogate_sol.res))
-    @error h, surrogate_sol.converged
+        if typeof(psid_surrogate) == PSIDS.SteadyStateNODEObs
+            PSIDS.set_initializer_parameters!(
+                psid_surrogate,
+                θ[θ_ranges["initializer_range"]],
+            )
+            PSIDS.set_node_parameters!(psid_surrogate, θ[θ_ranges["node_range"]])
+            PSIDS.set_observer_parameters!(psid_surrogate, θ[θ_ranges["observation_range"]])
+        elseif typeof(psid_surrogate) == PSIDS.SteadyStateNODE
+            PSIDS.set_initializer_parameters!(
+                psid_surrogate,
+                θ[θ_ranges["initializer_range"]],
+            )
+            PSIDS.set_node_parameters!(psid_surrogate, θ[θ_ranges["node_range"]])
+        end
+        display(psid_surrogate)
+        #WANT TO TEST IF A STEADY STATE CONDITION WAS FOUND FOR THESE CONDITIONS 
+        Vr0 = 0.89
+        Vi0 = 0.11
+        Ir0 = 0.51
+        Ii0 = 0.01
+        Vmag = sqrt(Vr0^2 + Vi0^2)
+        ang = atan(Vi0 / Vr0)
+        V = Vr0 + im * Vi0
+        I = Ir0 + im * Ii0
+        S = V * conj(I)
+        P0 = real(S)
+        Q0 = imag(S)
+        ex = t -> [Vr0, Vi0]
+        surrogate_sol = train_surrogate(ex, [Vr0, Vi0], [Ir0, Ii0], 0:0.1:1.0, 0:0.1:1.0)
+
+        sys = System(100.0)
+        b = Bus(
+            number = 1,
+            name = "01",
+            bustype = BusTypes.REF,
+            angle = ang,
+            magnitude = Vmag,
+            voltage_limits = (0.0, 2.0),
+            base_voltage = 230,
+        )
+        add_component!(sys, b)
+
+        s1 = Source(
+            name = "source_1",
+            available = true,
+            bus = b,
+            active_power = -P0,
+            reactive_power = -Q0,
+            R_th = 1e-5,
+            X_th = 1e-5,
+        )
+        add_component!(sys, s1)
+        s2 = Source(
+            name = "test-source",
+            available = true,
+            bus = b,
+            active_power = P0,
+            reactive_power = Q0,
+            R_th = 1e-5,
+            X_th = 1e-5,
+        )
+        add_component!(sys, s2)
+        add_component!(sys, psid_surrogate, s2)
+
+        #NOTE: was unable to test logs that are generated by Simulation!(...)
+        #@test_logs (:warn, "Initialization in SteadyStateNODEObs failed") match_mode=:any Simulation!(MassMatrixModel, sys, pwd(), (0.0, 1.0)) 
+        sim = Simulation!(MassMatrixModel, sys, pwd(), (0.0, 1.0))
+
+        if sim.status == PSID.BUILT    #Note: just because sim.status == PSID.BUILT does not guarantee an initialization to tolerance took place (see note above about logging)
+            psid_converged = true
+        else
+            psid_converged = false
+        end
+
+        @test surrogate_sol.converged
+        @test psid_converged
+
+        #Display the initial conditions for flux and psid surrogates (not exactly the same, expected for untrained surrogate?)
+        show_states_initial_value(sim)
+        @warn "value of states that satisfy NLsolve in flux surrogate $(surrogate_sol.r0)"
+    end
 end
-@assert false

--- a/test/test_psidsurrogate_vs_trainsurrogate.jl
+++ b/test/test_psidsurrogate_vs_trainsurrogate.jl
@@ -1,6 +1,5 @@
 
-@testset "Compare PSID and Training Surrogate - FrequencyChirp" begin
-
+@testset "Compare SteadyStateNODEObs and Training Surrogate - FrequencyChirp" begin
     #READ SYSTEM WITHOUT GENS 
     sys = System(joinpath(TEST_FILES_DIR, "system_data/2bus_nogens.raw"))
     include(joinpath(TEST_FILES_DIR, "system_data/dynamic_components_data.jl"))
@@ -48,6 +47,12 @@
             width_layers = 4,
             activation = "hardtanh",
             σ2_initialization = 0.1,
+        ),
+        model_observation = (
+            type = "dense",
+            n_layer = 0,
+            width_layers = 4,
+            activation = "hardtanh",
         ),
         train_data = (
             id = "1",
@@ -134,6 +139,214 @@
     PSIDS.set_observer_parameters!(
         psid_surrogate,
         θ[(train_surrogate.len + train_surrogate.len2 + 1):end],
+    )
+
+    b = collect(get_components(Bus, sys_train))[1]
+
+    #Add a source to attach the surrogate to
+    source_surrogate = Source(
+        name = "source_surrogate",
+        active_power = -1.0,
+        available = true,
+        reactive_power = -0.1,
+        bus = b,
+        R_th = 5e-6,
+        X_th = 5e-6,
+    )
+    add_component!(sys_train, source_surrogate)
+
+    #ADD THE SURROGATE COMPONENT 
+    for s in get_components(Source, sys_train)
+        if get_name(s) == "source_1"
+            chirp = FrequencyChirpVariableSource(
+                name = get_name(s),
+                R_th = get_R_th(s),
+                X_th = get_X_th(s),
+                ω1 = 2 * pi * 3,
+                ω2 = 2 * pi * 3,
+                tstart = 0.1,
+                N = 0.5,
+                V_amp = 0.2,
+                ω_amp = 0.2,
+            )
+
+            add_component!(sys_train, chirp, s)
+        end
+        if get_name(s) == "source_surrogate"
+            set_name!(psid_surrogate, get_name(s))
+            add_component!(sys_train, psid_surrogate, s)
+        end
+    end
+
+    #Remove the true model (the PowerLoad)
+    for P in get_components(PowerLoad, sys_train)
+        remove_component!(sys_train, P)
+    end
+
+    #Set reactive power of the Chirp Source to be 0.1
+    set_reactive_power!(get_component(Source, sys_train, "source_1"), 0.1)
+
+    #SIMULATE AND PLOT
+    sim = Simulation!(MassMatrixModel, sys_train, pwd(), (0.0, 1.0))
+    show_states_initial_value(sim)
+    execute!(sim, Rodas5(), abstol = 1e-9, reltol = 1e-9)
+    results = read_results(sim)
+    Vm2 = get_voltage_magnitude_series(results, 2)
+    θ2 = get_voltage_angle_series(results, 2)
+    Ir = get_real_current_series(results, "source_1")
+    Ii = get_imaginary_current_series(results, "source_1")
+    plot!(p3, Vm2, label = "Vm2 - psid")
+    plot!(p4, θ2, label = "θ2 - psid")
+    #NOTE: i_surrogate = - i_source
+    plot!(p1, Ir[1], -1 .* Ir[2], label = "real current -psid", legend = :topright)
+    plot!(p2, Ii[1], -1 .* Ii[2], label = "imag current -psid", legend = :topright)
+    display(plot(p1, p2, p3, p4, size = (1000, 1000)))
+
+    #@test LinearAlgebra.norm(Ir[2] .* -1 .- surrogate_sol.i_series[1, :], Inf) <= 5e-4
+
+    #See the distribution of the parameters
+    #= p_params = scatter(θ[(train_surrogate.len + 1):(train_surrogate.len + train_surrogate.len2)], label = "node params")
+    scatter!(p_params, θ[1:(train_surrogate.len)], label = "init params")
+    scatter!(p_params, θ[(train_surrogate.len + train_surrogate.len2 + 1):end], label = "observe params")
+    display(p_params) =#
+end
+
+@testset "Compare SteadyStateNODE and Training Surrogate - FrequencyChirp" begin
+    #READ SYSTEM WITHOUT GENS 
+    sys = System(joinpath(TEST_FILES_DIR, "system_data/2bus_nogens.raw"))
+    include(joinpath(TEST_FILES_DIR, "system_data/dynamic_components_data.jl"))
+
+    #ADD A SOUCE AND A LOAD
+    for b in get_components(Bus, sys)
+        if get_number(b) == 1
+            source = Source(
+                name = "source_$(get_name(b))",
+                active_power = 1.0,
+                available = true,
+                reactive_power = 0.1,
+                bus = b,
+                R_th = 5e-6,
+                X_th = 5e-6,
+            )
+            add_component!(sys, source)
+        end
+        if get_number(b) == 2
+            l = PowerLoad(
+                name = "Load_2",
+                available = true,
+                base_power = 100.0,
+                model = LoadModels.ConstantImpedance,
+                bus = b,
+                active_power = 1.0,
+                reactive_power = 0.1,
+                max_active_power = 2.0,
+                max_reactive_power = 2.0,
+            )
+            add_component!(sys, l)
+        end
+    end
+
+    #SERIALIZE TO SYSTEM
+    to_json(sys, joinpath(pwd(), "test", "system_data", "test.json"), force = true)
+
+    #DEFAULT PARAMETERS FOR THAT SYSTEM
+    p = TrainParams(
+        base_path = joinpath(pwd(), "test"),
+        surrogate_buses = [2],
+        model_node = (
+            type = "dense",
+            n_layer = 1,
+            width_layers = 4,
+            activation = "hardtanh",
+            σ2_initialization = 0.1,
+        ),
+        model_observation = (
+            type = "DirectObservation",
+            n_layer = 0,
+            width_layers = 4,
+            activation = "hardtanh",
+        ),
+        train_data = (
+            id = "1",
+            operating_points = PSIDS.SurrogateOperatingPoint[PSIDS.GenerationLoadScale()],
+            perturbations = [[
+                Chirp(
+                    source_name = "source_1",
+                    ω1 = 2 * pi * 3,
+                    ω2 = 2 * pi * 3,
+                    tstart = 0.1,
+                    N = 0.5,
+                    V_amp = 0.2,
+                    ω_amp = 0.2,
+                ),
+            ]],
+            params = PSIDS.GenerateDataParams(
+                solver = "Rodas5",
+                solver_tols = (reltol = 1e-6, abstol = 1e-6),
+                tspan = (0.0, 1.0),
+                tstops = 0.0:0.001:1.0,
+                tsave = 0.0:0.001:1.0,
+                formulation = "MassMatrix",
+                all_branches_dynamic = false,
+                all_lines_dynamic = false,
+                seed = 2,
+            ),
+            system = "reduced", #Use the reduced system to generate the data!
+        ),
+        system_path = joinpath(pwd(), "test", "system_data", "test.json"),
+        rng_seed = 4,
+        hidden_states = 3,
+        dynamic_solver = (solver = "Rodas5", reltol = 1e-6, abstol = 1e-6, maxiters = 1e5),
+    )
+
+    build_subsystems(p)
+    mkpath(joinpath(p.base_path, PowerSimulationNODE.INPUT_FOLDER_NAME))
+    generate_train_data(p)
+    Random.seed!(p.rng_seed) #Seed call usually happens at start of train()
+    train_dataset = Serialization.deserialize(p.train_data_path)
+    scaling_extrema = PowerSimulationNODE.calculate_scaling_extrema(train_dataset)
+    sys_validation = System(p.surrogate_system_path)
+    sys_train = System(p.train_system_path)
+    exs = PowerSimulationNODE._build_exogenous_input_functions(p.train_data, train_dataset)
+    v0 = [
+        train_dataset[1].surrogate_real_voltage[1],
+        train_dataset[1].surrogate_imag_voltage[1],
+    ]
+    i0 = [train_dataset[1].real_current[1], train_dataset[1].imag_current[1]]
+
+    tsteps = train_dataset[1].tsteps
+    tstops = train_dataset[1].tstops
+    Vr1_flux = [exs[1](t)[1] for t in tsteps]
+    Vi1_flux = [exs[1](t)[2] for t in tsteps]
+    Vm1_flux = sqrt.(Vr1_flux .^ 2 .+ Vi1_flux .^ 2)
+    θ1_flux = atan.(Vi1_flux, Vr1_flux)
+    p3 = plot(tsteps, Vm1_flux, label = "Vm1 - flux")
+    p4 = plot(tsteps, θ1_flux, label = "θ1 - flux")
+
+    connecting_branches = Serialization.deserialize(p.data_collection_location_path)[2]
+
+    #INSTANTIATE BOTH TYPES OF SURROGATES 
+    train_surrogate = PowerSimulationNODE.instantiate_surrogate_flux(p, 1, scaling_extrema)
+    psid_surrogate =
+        PowerSimulationNODE.instantiate_surrogate_psid(p, 1, scaling_extrema, "test-source")
+    surrogate_sol = train_surrogate(exs[1], v0, i0, tsteps, tstops)
+    p1 = plot(
+        surrogate_sol.t_series,
+        surrogate_sol.i_series[1, :],
+        label = "real current - flux",
+    )
+    p2 = plot(
+        surrogate_sol.t_series,
+        surrogate_sol.i_series[2, :],
+        label = "imag current - flux",
+    )
+
+    #SET THE PARAMETERS OF THE PSID SURROGATE FROM THE FLUX ONE 
+    θ, _ = Flux.destructure(train_surrogate)
+    PSIDS.set_initializer_parameters!(psid_surrogate, θ[1:(train_surrogate.len)])
+    PSIDS.set_node_parameters!(
+        psid_surrogate,
+        θ[(train_surrogate.len + 1):(train_surrogate.len + train_surrogate.len2)],
     )
 
     b = collect(get_components(Bus, sys_train))[1]

--- a/test/test_relative_angle.jl
+++ b/test/test_relative_angle.jl
@@ -1,6 +1,5 @@
 #The goal of this test is to make sure the surrogate model does not depend on the absolute value of voltage angle.
-#A test is shown with a gfl inverter and then repeated for the surrogate.
-#TODO - this test was not run for a while, need to clean it up. 
+#A test is shown with a gfl inverter and then repeated for each surrogate model.
 function pvs_simple(source)
     return PeriodicVariableSource(
         name = get_name(source),
@@ -16,7 +15,7 @@ function pvs_simple(source)
 end
 
 @testset "Compare gfl response for different angle reference" begin
-    sys = System(joinpath(TEST_FILES_DIR, "system_data/3bus_nogens.raw"))
+    sys = System(joinpath(TEST_FILES_DIR, "system_data/3bus_nogens.raw"))   #3 buses connected by 2 branches
     include(joinpath(TEST_FILES_DIR, "system_data/dynamic_components_data.jl"))
     for b in get_components(Bus, sys)
         if get_number(b) == 1
@@ -47,12 +46,6 @@ end
         end
         if get_number(b) == 3
             gen = collect(get_components(ThermalStandard, sys))[1]
-            #source version             
-            #= remove_component!(sys, gen)
-            source = Source( name = "source_$(get_name(b))", active_power= 1.0, available = true, reactive_power = 0.0, bus = b, R_th = 0.0, X_th = 5e-6)
-            add_component!(sys, source) =#
-
-            #gen version 
             gfl = inv_gfoll(gen)
             add_component!(sys, gfl, gen)
         end
@@ -100,8 +93,7 @@ end
     @test LinearAlgebra.norm(Im23_ref1 .- Im23_ref2, Inf) <= 1e-3
 end
 
-#NOTE - once we develop this test we can delete the test above... no need to test the gfl in this package. 
-#= @testset "Compare surrogate response for different angle reference" begin
+@testset "Compare SteadyStateNodeObs response for different angle reference" begin
     sys = System(joinpath(TEST_FILES_DIR, "system_data/3bus_nogens.raw"))
     include(joinpath(TEST_FILES_DIR, "system_data/dynamic_components_data.jl"))
 
@@ -112,6 +104,12 @@ end
             width_layers = 4,
             activation = "hardtanh",
             σ2_initialization = 0.05,
+        ),
+        model_observation = (
+            type = "dense",
+            n_layer = 0,
+            width_layers = 4,
+            activation = "hardtanh",
         ),
     )
     scaling_extrema = Dict{}(
@@ -162,7 +160,6 @@ end
         end
         if get_number(b) == 3
             gen = collect(get_components(ThermalStandard, sys))[1]
-            #source version             
             remove_component!(sys, gen)
             source = Source(
                 name = "source_$(get_name(b))",
@@ -173,14 +170,9 @@ end
                 R_th = 0.0,
                 X_th = 5e-6,
             )
-
             add_component!(sys, source)
             set_name!(psid_surrogate, get_name(source))
             add_component!(sys, psid_surrogate, source)
-
-            #gen version 
-            #gfl = inv_gfoll(gen)
-            #add_component!(sys, gfl, gen)
         end
     end
     node_run_powerflow!(sys)
@@ -226,4 +218,129 @@ end
     @test LinearAlgebra.norm(Ii23_ref1 .- Ii23_ref2, Inf) >= 1e-2
     @test LinearAlgebra.norm(Im23_ref1 .- Im23_ref2, Inf) <= 1e-3
 end
- =#
+
+@testset "Compare SteadyStateNode response for different angle reference" begin
+    sys = System(joinpath(TEST_FILES_DIR, "system_data/3bus_nogens.raw"))
+    include(joinpath(TEST_FILES_DIR, "system_data/dynamic_components_data.jl"))
+
+    p = TrainParams(
+        model_node = (
+            type = "dense",
+            n_layer = 1,
+            width_layers = 4,
+            activation = "hardtanh",
+            σ2_initialization = 0.05,
+        ),
+        model_observation = (
+            type = "DirectObservation",
+            n_layer = 0,
+            width_layers = 4,
+            activation = "hardtanh",
+        ),
+    )
+    scaling_extrema = Dict{}(
+        "target_max" => [1.0, 1.0],
+        "target_min" => [-1.0, -1.0],
+        "input_max" => [1.0, 1.0],
+        "input_min" => [-1.0, -1.0],
+    )
+    train_surrogate = PowerSimulationNODE.instantiate_surrogate_flux(p, 1, scaling_extrema)
+    psid_surrogate =
+        PowerSimulationNODE.instantiate_surrogate_psid(p, 1, scaling_extrema, "test-source")
+    θ, _ = Flux.destructure(train_surrogate)
+    PSIDS.set_initializer_parameters!(psid_surrogate, θ[1:(train_surrogate.len)])
+    PSIDS.set_node_parameters!(
+        psid_surrogate,
+        θ[(train_surrogate.len + 1):(train_surrogate.len + train_surrogate.len2)],
+    )
+    #=     PSIDS.set_observer_parameters!(
+            psid_surrogate,
+            θ[(train_surrogate.len + train_surrogate.len2 + 1):end],
+        ) =#
+    for b in get_components(Bus, sys)
+        if get_number(b) == 1
+            source = Source(
+                name = "source_$(get_name(b))",
+                active_power = 1.0,
+                available = true,
+                reactive_power = 0.0,
+                bus = b,
+                R_th = 0.0,
+                X_th = 5e-6,
+            )
+            add_component!(sys, source)
+        end
+        if get_number(b) == 2
+            source = Source(
+                name = "source_$(get_name(b))",
+                active_power = 1.0,
+                available = true,
+                reactive_power = 0.0,
+                bus = b,
+                R_th = 0.0,
+                X_th = 5e-6,
+            )
+            add_component!(sys, source)
+            pvs = pvs_simple(source)
+            add_component!(sys, pvs, source)
+        end
+        if get_number(b) == 3
+            gen = collect(get_components(ThermalStandard, sys))[1]
+            remove_component!(sys, gen)
+            source = Source(
+                name = "source_$(get_name(b))",
+                active_power = 1.0,
+                available = true,
+                reactive_power = 0.0,
+                bus = b,
+                R_th = 0.0,
+                X_th = 5e-6,
+            )
+            add_component!(sys, source)
+            set_name!(psid_surrogate, get_name(source))
+            add_component!(sys, psid_surrogate, source)
+        end
+    end
+    node_run_powerflow!(sys)
+    sim = Simulation!(MassMatrixModel, sys, pwd(), (0.0, 1.0))
+    show_states_initial_value(sim)
+    execute!(sim, Rodas5(), saveat = 0.0:0.01:1.0)
+    results = read_results(sim)
+    Vm3_ref1 = get_voltage_magnitude_series(results, 3)[2]
+    θ3_ref1 = get_voltage_angle_series(results, 3)[2]
+    Ir23_ref1 = get_real_current_branch_flow(results, "BUS 2-BUS 3-i_1")[2]
+    Ii23_ref1 = get_imaginary_current_branch_flow(results, "BUS 2-BUS 3-i_1")[2]
+    Im23_ref1 = sqrt.(Ir23_ref1 .^ 2 .+ Ii23_ref1 .^ 2)
+
+    for b in get_components(Bus, sys)
+        if get_number(b) == 1
+            set_bustype!(b, PowerSystems.BusTypes.PQ)
+        end
+        if get_number(b) == 2
+            set_bustype!(b, PowerSystems.BusTypes.REF)
+            set_angle!(b, 0.0)
+        end
+    end
+
+    node_run_powerflow!(sys)
+    sim = Simulation!(MassMatrixModel, sys, pwd(), (0.0, 1.0))
+    execute!(sim, Rodas5(), saveat = 0.0:0.01:1.0)
+    results = read_results(sim)
+    Vm3_ref2 = get_voltage_magnitude_series(results, 3)[2]
+    θ3_ref2 = get_voltage_angle_series(results, 3)[2]
+    Ir23_ref2 = get_real_current_branch_flow(results, "BUS 2-BUS 3-i_1")[2]
+    Ii23_ref2 = get_imaginary_current_branch_flow(results, "BUS 2-BUS 3-i_1")[2]
+    Im23_ref2 = sqrt.(Ir23_ref2 .^ 2 .+ Ii23_ref2 .^ 2)
+
+    p1 = plot(θ3_ref1, label = "θdevice - ref bus 1")
+    plot!(p1, θ3_ref2, label = "θdevice - ref bus 2")
+    p2 = plot(Im23_ref1, label = "Im_device - ref bus 1", legend = :bottomright)
+    plot!(p2, Im23_ref2, label = "Im_device - ref bus 2", legend = :bottomright)
+    #display(plot(p1, p2))
+
+    @test LinearAlgebra.norm(Vm3_ref1 .- Vm3_ref2, Inf) <= 1e-3
+    @test LinearAlgebra.norm(θ3_ref1 .- θ3_ref2, Inf) >= 1e-2
+    @test LinearAlgebra.norm(Ir23_ref1 .- Ir23_ref2, Inf) >= 1e-2
+    @test LinearAlgebra.norm(Ii23_ref1 .- Ii23_ref2, Inf) >= 1e-2
+    @test LinearAlgebra.norm(Im23_ref1 .- Im23_ref2, Inf) <= 1e-3
+end


### PR DESCRIPTION
- Adds a `visualize_loss `function which can be used to visualize how a surrogate is performing across an entire dataset (train, validation, or test). This function is exported so it can be used in PowerSystemNODEs.
- Make force_tstop a parameter so we can see how it impacts the quality and efficiency of training.
- Make it possible to have a surrogate without the "observation" NN. The alternative is to just choose the first two hidden states and scale them and make them the output current. You do this by setting model_observation.type to "DirectObservation".
- Returned to two tests that had been commented (test_NLsolve.jl and test_relativeangle.jl"). Cleaned them up a bit. 